### PR TITLE
Added first few contextual links

### DIFF
--- a/elements/location-narrative.js
+++ b/elements/location-narrative.js
@@ -40,10 +40,11 @@ module.exports = function (state, send) {
     return map(xtend(mapstate, { dataset: dataset, geojson: data[dataset].feature }))
   }
 
+  // giving just the general link for this one because there doesn't seem to be a readily automatable way to link to the district's representative, as opposed to a district map that lacks the information most users will probably want}
   if (data['city-council-districts']) {
     append(html`<div class="list-item">
       <h2>City council district</h2>
-      <p>This location is in <b>city council district ${data['city-council-districts'].district}</b>.</p>
+      <p>This location is in <b><a href="http://www.seattle.gov/cityclerk/municipal-code-and-city-charter/council-districts">city council district</a> ${data['city-council-districts'].district}</b>.</p>
       ${createMap('city-council-districts', mapstate)}
     </div>`)
   }

--- a/elements/location-narrative.js
+++ b/elements/location-narrative.js
@@ -70,9 +70,10 @@ module.exports = function (state, send) {
     append(html`<p>This location is not inside any school districts.`)
   }
   if (data['sps-es']) {
+  	console.log(data['sps-es'])
     append(html`<div class="list-item">
       <h3>Elementary school</h3>
-      <p>${data['sps-es']['ES_ZONE']}</p>
+      <p><a href="http://www.seattleschools.org/directory/elementary_schools/${data['sps-es']['ES_ZONE'].replace(/\./g,'').replace(/\s+/g,'_').replace('Wing_Luke','luke').replace('MLK_Jr','king').replace('Thurgood_Marshall','marshall').replace('John_Muir','muir').replace('John_Rogers','rogers')}/">${data['sps-es']['ES_ZONE']}</></p>
       ${createMap('sps-es', mapstate)}
     </div>`)
   }

--- a/elements/location-narrative.js
+++ b/elements/location-narrative.js
@@ -116,7 +116,7 @@ module.exports = function (state, send) {
   if (data['wa-legislature']) {
     append(html`<div class="list-item">
       <h2>Washington legislature</h2>
-      <p>${data['wa-legislature']['NAMELSAD10']}</p>
+      <p><a href="http://app.leg.wa.gov/districtfinder/displaydistrict/${data['wa-legislature']['NAMELSAD10'].replace(/[^0-9\.]/g, '')}">${data['wa-legislature']['NAMELSAD10']}</a></p>
       ${createMap('wa-legislature', mapstate)}
     </div>`)
   }


### PR DESCRIPTION
Partial progress on #4
Caveats:

* City Council Districts just link to a general info page, because I couldn’t find a useful way to go direct to the district without losing representatives’ info
* Elementary Schools are a bit special case heavy.  There must be a better way to handle that.